### PR TITLE
Add Softwire consultant CV; correct AI claims across CVs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,7 @@ on:
       - ".aspell.en.pws"
       - "leadership-cv.tex"
       - "advisory-cv.tex"
+      - "consultant-cv.tex"
       - "cv.sty"
       - "Makefile"
       - ".github/workflows/publish.yml"
@@ -15,6 +16,7 @@ on:
       - ".aspell.en.pws"
       - "leadership-cv.tex"
       - "advisory-cv.tex"
+      - "consultant-cv.tex"
       - "cv.sty"
       - "Makefile"
       - ".github/workflows/publish.yml"
@@ -53,6 +55,13 @@ jobs:
               - '.github/workflows/pr.yml'
             advisory-cv:
               - 'advisory-cv.tex'
+              - '.aspell.en.pws'
+              - 'cv.sty'
+              - 'Makefile'
+              - '.github/workflows/publish.yml'
+              - '.github/workflows/pr.yml'
+            consultant-cv:
+              - 'consultant-cv.tex'
               - '.aspell.en.pws'
               - 'cv.sty'
               - 'Makefile'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
       - ".aspell.en.pws"
       - "leadership-cv.tex"
       - "advisory-cv.tex"
+      - "consultant-cv.tex"
       - "cv.sty"
       - "Makefile"
       - ".github/workflows/publish.yml"
@@ -42,6 +43,13 @@ jobs:
               - '.github/workflows/pr.yml'
             advisory-cv:
               - 'advisory-cv.tex'
+              - '.aspell.en.pws'
+              - 'cv.sty'
+              - 'Makefile'
+              - '.github/workflows/publish.yml'
+              - '.github/workflows/pr.yml'
+            consultant-cv:
+              - 'consultant-cv.tex'
               - '.aspell.en.pws'
               - 'cv.sty'
               - 'Makefile'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-CVS := leadership-cv advisory-cv
+CVS := leadership-cv advisory-cv consultant-cv
 PDFS := $(CVS:%=%.pdf)
 LEADERSHIP_RELEASE_PDF := Oscar.Barlow.Leadership.CV.$(DATE).pdf
 ADVISORY_RELEASE_PDF := Oscar.Barlow.Advisory.CV.$(DATE).pdf
+CONSULTANT_RELEASE_PDF := Oscar.Barlow.Consultant.CV.$(DATE).pdf
 
 default: local
 
@@ -11,7 +12,7 @@ ci: spellcheck check-length rename publish
 clean:
 	rm -f $(CVS:%=%.aux) $(CVS:%=%.log) $(CVS:%=%.out)
 	rm -f $(PDFS)
-	rm -f Oscar.Barlow.Leadership.CV.*.pdf Oscar.Barlow.Advisory.CV.*.pdf
+	rm -f Oscar.Barlow.Leadership.CV.*.pdf Oscar.Barlow.Advisory.CV.*.pdf Oscar.Barlow.Consultant.CV.*.pdf
 
 .PHONY: check-length
 check-length: create-pdf
@@ -38,7 +39,7 @@ local: create-pdf check-length set-date rename
 
 .PHONY: publish
 publish:
-	gh release create "$(DATE)" -t "Oscar Barlow CVs $(DATE)" -n "Oscar Barlow's CVs for $(DATE). PDFs are available to download from the links below." "$(GITHUB_WORKSPACE)/$(LEADERSHIP_RELEASE_PDF)" "$(GITHUB_WORKSPACE)/$(ADVISORY_RELEASE_PDF)"
+	gh release create "$(DATE)" -t "Oscar Barlow CVs $(DATE)" -n "Oscar Barlow's CVs for $(DATE). PDFs are available to download from the links below." "$(GITHUB_WORKSPACE)/$(LEADERSHIP_RELEASE_PDF)" "$(GITHUB_WORKSPACE)/$(ADVISORY_RELEASE_PDF)" "$(GITHUB_WORKSPACE)/$(CONSULTANT_RELEASE_PDF)"
 
 .PHONY: rename
 rename:
@@ -46,6 +47,7 @@ rename:
 		case "$$cv" in \
 			leadership-cv) output="$(LEADERSHIP_RELEASE_PDF)" ;; \
 			advisory-cv) output="$(ADVISORY_RELEASE_PDF)" ;; \
+			consultant-cv) output="$(CONSULTANT_RELEASE_PDF)" ;; \
 			*) echo "Unknown CV: $$cv" >&2; exit 1 ;; \
 		esac; \
 		mv "$$cv.pdf" "$$output"; \

--- a/advisory-cv.tex
+++ b/advisory-cv.tex
@@ -29,7 +29,7 @@
     including overseeing model risk, responsible AI assurance, and enabling innovation within FCA expectations.
   \item \textbf{Strategic challenge grounded in technical reality:} I can assess risk without needing things translated,
     and I'll ask the uncomfortable questions early.
-  \item \textbf{External voice:} Regular speaker at financial services industry events and podcasts on industry podcasts on responsible AI in regulated environments.
+  \item \textbf{External voice:} Speaker on responsible AI in regulated environments, including the Banking Transformation Summit and the Cambridge Judge Business School podcast.
 \end{itemize}
 
 \section*{Career Highlights}

--- a/consultant-cv.tex
+++ b/consultant-cv.tex
@@ -15,10 +15,10 @@
 \section*{Profile}
 { % Start of local scope
   \setlength{\parskip}{6pt plus 2pt minus 1pt}
-  I build the data and AI systems that regulated institutions run on, and the governance that lets them
-  put AI into production with the regulator onside. At Starling Bank I've worked both sides of that
-  problem: the streaming platform and ML systems underneath, and the model-risk and assurance frameworks
-  on top that turned AI from a compliance worry into shipped product. I'm an engineer first, so I know
+  I offer banks and insurers senior engineering leadership for the AI problem they can't afford to get
+  wrong: putting it into production, safely, under regulatory scrutiny. At Starling Bank I worked both sides of that
+  problem. I built the streaming platform and ML systems underneath, and the model-risk and assurance
+  frameworks on top that turned AI from a compliance worry into shipped product. I'm an engineer first, so I know
   what's buildable because I've built it: set the direction, energised the team, and owned the hard calls.
 } % End of local scope
 
@@ -30,10 +30,10 @@
   \item \textbf{Data foundations worth building on:} most AI problems are really data problems; I've built
     the streaming platforms and governed, cloud-native warehouses a bank can genuinely trust.
   \item \textbf{Models that stay reliable:} a model that works in a notebook and one that holds up against
-    fraud for years are different problems --- I know the failure modes (drift, brittle features, stale
+    fraud for years are different problems. I know the failure modes (drift, brittle features, stale
     refresh) and how to design them out.
-  \item \textbf{Teams that outlast the engagement:} I build engineering organisations, not dependencies
-    --- the hiring bars, tooling and rituals that keep delivery fast and safe long after I've gone.
+  \item \textbf{Teams that outlast the engagement:} I build engineering organisations, not dependencies,
+    and put in place the hiring bars, tooling and rituals that keep delivery fast and safe long after I've gone.
 \end{itemize}
 
 \section*{Selected Experience}
@@ -42,8 +42,8 @@
 \textbf{January 2025--Present}
 
 Lead Starling's company-wide AI adoption and built its Responsible AI Innovation team from scratch.
-Overhauled model-risk and governance so the bank could put AI into production under FCA expectations ---
-work that helped ship three public-facing AI features and drove daily AI use across staff to 70\%. I
+Overhauled model-risk and governance so the bank could put AI into production under FCA expectations. That
+work helped ship three public-facing AI features and drove daily AI use across staff to 70\%. I
 also speak externally on AI in banking, including at the Banking Transformation Summit and on the
 Cambridge Judge Business School podcast.
 

--- a/consultant-cv.tex
+++ b/consultant-cv.tex
@@ -1,0 +1,72 @@
+\documentclass[a4paper]{scrartcl}
+
+\usepackage{cv}
+
+\author{Oscar Barlow}
+\title{Oscar Barlow}
+\cvsubtitle{Engineering leader --- AI \& data systems in regulated financial services}
+\date{}
+\pagestyle{empty}
+
+\begin{document}
+
+\maketitle
+
+\section*{Profile}
+{ % Start of local scope
+  \setlength{\parskip}{6pt plus 2pt minus 1pt}
+  I build the data and AI systems that regulated banks run on --- and the governance that lets them
+  put AI into production with the regulator onside. At Starling Bank I've worked both sides of that
+  problem: the streaming platform and ML systems underneath, and the model-risk and assurance frameworks
+  on top that turned AI from a compliance worry into shipped product. I'm an engineer first, so I know
+  what's buildable because I've built it. In a delivery team, that's senior judgement grounded in the
+  work: I shape the architecture, pressure-test the plan, and raise the hard questions while they're
+  still cheap to fix.
+} % End of local scope
+
+\section*{How I Help}
+\begin{itemize}
+  \item \textbf{Getting AI into production, safely:} the hard part is rarely the model --- it's the
+    model-risk, assurance and live monitoring (fairness, uncertainty) that make it defensible enough to
+    ship in a regulated business. I've built that path end to end.
+  \item \textbf{Data foundations worth building on:} most AI problems are really data problems; I've built
+    the streaming platforms and governed, cloud-native warehouses a bank can genuinely trust.
+  \item \textbf{Models that stay reliable:} a model that works in a notebook and one that holds up against
+    fraud for years are different problems --- I know the failure modes (drift, brittle features, stale
+    refresh) and how to design them out.
+  \item \textbf{Teams that outlast the engagement:} I build engineering organisations, not dependencies
+    --- the hiring bars, tooling and rituals that keep delivery fast and safe long after I've gone.
+\end{itemize}
+
+\section*{Selected Experience}
+
+\subsection*{Head of AI Advocacy --- Starling Bank}
+\textbf{January 2025--Present}
+
+Lead Starling's company-wide AI adoption and built its Responsible AI Innovation team from scratch.
+Overhauled model-risk and governance so the bank could put AI into production under FCA expectations ---
+work that helped ship three public-facing AI features and drove daily AI use across staff to 70\%. I
+also speak externally on AI in banking, including at the Banking Transformation Summit and on the
+Cambridge Judge Business School podcast.
+
+\subsection*{Senior Engineering Manager, Data \& AI --- Starling Bank}
+\textbf{November 2021--December 2024}
+
+Built Starling's streaming data platform (Kafka) and cloud-native warehouse (BigQuery, dbt), giving the
+whole business trusted, self-serve data. Re-engineered the fraud-model training architecture to prevent
+£2M in annual losses, and doubled ML deployment frequency by rebuilding the MLOps tooling and guardrails.
+Grew the data engineering organisation from 6 to 25.
+
+\subsection*{Senior Consultant --- Infinity Works (Accenture)}
+\textbf{June 2017--October 2021}
+
+Built data and AI systems for clients across financial services and retail. Rescued a failing
+competitive-intelligence platform at Sainsbury's, rebuilding the architecture to a production launch in
+three months and unlocking six-figure gains. Delivered the data pipelines for a £10M cloud migration
+(Snowflake), reporting directly to the CTO.
+
+\section*{Education}
+MSc International Marketing --- Birkbeck, University of London \\
+BA (Hons) Philosophy --- University of Nottingham
+
+\end{document}

--- a/consultant-cv.tex
+++ b/consultant-cv.tex
@@ -15,19 +15,17 @@
 \section*{Profile}
 { % Start of local scope
   \setlength{\parskip}{6pt plus 2pt minus 1pt}
-  I build the data and AI systems that regulated banks run on --- and the governance that lets them
+  I build the data and AI systems that regulated institutions run on, and the governance that lets them
   put AI into production with the regulator onside. At Starling Bank I've worked both sides of that
   problem: the streaming platform and ML systems underneath, and the model-risk and assurance frameworks
   on top that turned AI from a compliance worry into shipped product. I'm an engineer first, so I know
-  what's buildable because I've built it. In a delivery team, that's senior judgement grounded in the
-  work: I shape the architecture, pressure-test the plan, and raise the hard questions while they're
-  still cheap to fix.
+  what's buildable because I've built it: set the direction, energised the team, and owned the hard calls.
 } % End of local scope
 
 \section*{How I Help}
 \begin{itemize}
-  \item \textbf{Getting AI into production, safely:} the hard part is rarely the model --- it's the
-    model-risk, assurance and live monitoring (fairness, uncertainty) that make it defensible enough to
+  \item \textbf{Getting AI into production, safely:} the hard part is rarely the model. It's the
+    model risk, assurance and monitoring (fairness, uncertainty) that make it defensible enough to
     ship in a regulated business. I've built that path end to end.
   \item \textbf{Data foundations worth building on:} most AI problems are really data problems; I've built
     the streaming platforms and governed, cloud-native warehouses a bank can genuinely trust.

--- a/leadership-cv.tex
+++ b/leadership-cv.tex
@@ -15,7 +15,7 @@
 \section*{Personal Profile}
  { % Start of local scope
   \setlength{\parskip}{6pt plus 2pt minus 1pt}
-  Engineering leader who has built AI infrastructure, governance, and product capabilities at Starling Bank - from streaming data platforms serving 100+ users, to governance frameworks that doubled ML deployment velocity, to building customer-facing data science teams. Combines technical depth in AI/ML with strategic thinking about responsible innovation at scale.
+  Engineering leader who has built AI infrastructure, governance, and product capabilities at Starling Bank - from streaming data platforms serving 100+ users, to governance frameworks that doubled ML deployment velocity. Combines technical depth in AI/ML with strategic thinking about responsible innovation at scale.
 
   I thrive in ambiguous environments where the path isn't clear - I build alignment around where we need to go, attract the right people, and create the conditions for them to succeed. I am an unconventional thinker with an unconventional background, and this gives me versatility: I think in systems, communicate clearly across functions, and understand business strategy. This makes me effective at the parts of technology leadership that aren't about code: building alignment, representing technical vision externally, and creating cultures where diverse teams thrive
  } % End of local scope
@@ -34,12 +34,12 @@
 \subsection*{Head of AI Advocacy - Starling Bank}
 \textbf{January 2025--Present}
 
-Building Starling's business banking data science team from scratch to deliver customer-facing AI features (Q3 2026 launch), while leading organisation-wide AI adoption through governance, enablement, and external representation.
+Leading organisation-wide AI adoption through governance, enablement, and external representation.
 \begin{itemize}
 	\item Directed a cross-functional AI \& ML governance working group, overhauling model risk management and instituting proportionate guardrails that unlocked innovation while meeting regulatory expectations.
 	\item Led company-wide AI enablement initiative: coached executives, built community of 40+ AI Champions, and embedded adoption processes achieving 70\% daily staff usage
 	\item Built and led the Responsible AI Innovation team, contributing to the delivery of three public-facing AI features while exploring new assurance techniques so Starling can safely maximise AI value with customer transparency.
-	\item External voice for Starling's AI strategy: represent company at UK Finance AI Policy forum, regular speaker at FStech and Velocity conferences, featured on industry podcasts discussing responsible AI deployment in regulated environments
+	\item External voice for Starling's AI strategy: represent company at the UK Finance AI Policy forum, regular speaker at the Banking Transformation Summit, FStech, and Velocity conferences, and featured on the Cambridge Judge Business School podcast and other industry podcasts discussing responsible AI deployment in regulated environments
 \end{itemize}
 
 \subsection*{Senior Engineering Manager, Data \& AI - Starling Bank}


### PR DESCRIPTION
Add consultant-cv.tex: a one-page, FS&I-targeted, builder-first profile for Softwire to put in front of clients. Wire it into the Makefile and the PR/publish workflows alongside the existing two CVs.

Also correct factual claims in the existing CVs:
- Remove the business-banking data science team / customer-facing AI claim from the consultant and leadership CVs (not shipped, no longer active).
- Add named speaking venues (Banking Transformation Summit, Cambridge Judge Business School podcast) to all three CVs.
- Fix the garbled external-voice line in the advisory CV.